### PR TITLE
Add init-resources to allow individual schema registration.

### DIFF
--- a/resources/test_dummy.edn
+++ b/resources/test_dummy.edn
@@ -1,0 +1,4 @@
+[^{:lacinia/tag true
+   :graphviz/tag true
+   :graphviz/group :address}
+default]

--- a/src/hodur_engine/core.cljc
+++ b/src/hodur_engine/core.cljc
@@ -374,7 +374,6 @@
    (defn init-resources [resource & others]
      (let [resources (conj others resource)]
        (->> resources
-            (map io/file)
             slurp-files
             (apply init-schema)))))
 

--- a/src/hodur_engine/core.cljc
+++ b/src/hodur_engine/core.cljc
@@ -371,6 +371,14 @@
       (ensure-meta-db schema))))
 
 #?(:clj
+   (defn init-resources [resource & others]
+     (let [resources (conj others resource)]
+       (->> resources
+            (map io/file)
+            slurp-files
+            (apply init-schema)))))
+
+#?(:clj
    (defn init-path [path & others]
      (let [paths (-> others flatten (conj path) flatten)]
        (->> paths

--- a/test/hodur_engine/core_test.clj
+++ b/test/hodur_engine/core_test.clj
@@ -617,18 +617,26 @@
     (is (= 1 (count unions)))))
 
 (deftest multiple-path
-  (let [lacinia-c (engine/init-path "test/schemas/several/lacinia"
-                                    "test/schemas/several/shared")
-        datomic-c (engine/init-path "test/schemas/several/datomic"
-                                    "test/schemas/several/shared")]
-    (is (= 23 (count (d/q '[:find [?e ...]
+  (let [lacinia-c1 (engine/init-path "test/schemas/several/lacinia")
+        lacinia-c2 (engine/init-path "test/schemas/several/shared")
+        datomic-c1 (engine/init-path "test/schemas/several/datomic")
+        datomic-c2 (engine/init-path "test/schemas/several/shared")]
+    (is (= 12 (count (d/q '[:find [?e ...]
                             :where
                             [?e :node/type]]
-                          @lacinia-c))))
-    (is (= 25 (count (d/q '[:find [?e ...]
+                          @lacinia-c1))))
+    (is (= 17 (count (d/q '[:find [?e ...]
+                               :where
+                               [?e :node/type]]
+                             @lacinia-c2))))
+    (is (= 14 (count (d/q '[:find [?e ...]
                             :where
                             [?e :node/type]]
-                          @datomic-c))))))
+                          @datomic-c1))))
+    (is (= 17 (count (d/q '[:find [?e ...]
+                               :where
+                               [?e :node/type]]
+                             @datomic-c2))))))
 
 (deftest same-name-fields
   (let [c (engine/init-schema

--- a/test/hodur_engine/core_test.clj
+++ b/test/hodur_engine/core_test.clj
@@ -5,7 +5,8 @@
                                             ->snake_case_keyword]]
             [clojure.test :refer :all]
             [datascript.core :as d]
-            [hodur-engine.core :as engine]))
+            [hodur-engine.core :as engine]
+            [clojure.java.io :as io]))
 
 (defn ^:private init-and-pull
   [schema selector eid]
@@ -776,3 +777,13 @@
            (-> union-fields first :field/union-type :type/name)))
     (is (= (-> union-fields last  :field/name)
            (-> union-fields last  :field/union-type :type/name)))))
+
+(deftest init-resources-single-param
+  (let [init-path identity
+        result (engine/init-resources (io/resource "test_dummy.edn"))]
+    (is (contains? @result :schema))))
+
+(deftest init-resources-multiple-params
+         (let [init-path identity
+               result (engine/init-resources (io/resource "test_dummy.edn") (io/resource "test_dummy.edn"))]
+              (is (contains? @result :schema))))


### PR DESCRIPTION
This PR is a proposal to add a new function init-resources that allows clients to control explicitly which schemas should be handled by hodur.
The already existing function init-path assumes that all schemas on the given path should be processed.
In that sense, I believe init-resource adds value to the set of facilities that already exist in hodur.

This PR also adds a dummy schema file to resources, that serves the purpose of testing resource loading inside test-resources.

This PR also allows init-schema to initialize (and browse) a path from within an uberjar file that follows the Capsule strategy. This version only allows support for a single parameter for init-path though.