### PR TITLE
Add support for tagging with keywords

### DIFF
--- a/src/hodur_engine/core.cljc
+++ b/src/hodur_engine/core.cljc
@@ -223,20 +223,20 @@
 (defn ^:private merge-recursive
   [base rec sym]
   (reduce-kv
-   (fn [m k {:keys [only except] :as v}]
+   (fn [m k v]
      (let [tag-k (keyword (namespace k) "tag")]
-       (cond-> m
-         (or only except)
-         (dissoc tag-k)
-         
-         (= true v)
-         (assoc tag-k true)
+       (cond (map? v) (let [{:keys [only except]} v]
+                        (cond-> m
+                          (or only except)
+                          (dissoc tag-k)
 
-         (and only (some #(= sym %) only))
-         (assoc tag-k true)
+                          (and only (some #(= sym %) only))
+                          (assoc tag-k true)
 
-         (and except (not (some #(= sym %) except)))
-         (assoc tag-k true))))
+                          (and except (not (some #(= sym %) except)))
+                          (assoc tag-k true)))
+             v (assoc m tag-k v)
+             :else m)))
    (or base {}) rec))
 
 (defn ^:private conj-type

--- a/test/hodur_engine/core_test.clj
+++ b/test/hodur_engine/core_test.clj
@@ -776,3 +776,23 @@
            (-> union-fields first :field/union-type :type/name)))
     (is (= (-> union-fields last  :field/name)
            (-> union-fields last  :field/union-type :type/name)))))
+
+(deftest keyword-tags
+  (let [xs (init-and-query
+            '[^{:ns-prefix/tag-recursive :foo}
+              A
+              [af1 ^{:ns-prefix/tag false} af2]
+
+              B
+              [bf1]
+
+              C
+              [^{:ns-prefix/tag :bar} cf1]]
+            '[:find [(pull ?e [:type/name :field/name :ns-prefix/tag]) ...]
+              :where
+              [?e :ns-prefix/tag]])]
+    (is (= (set xs)
+           #{{:type/name "A", :ns-prefix/tag :foo}
+             {:field/name "af2", :ns-prefix/tag false}
+             {:field/name "af1", :ns-prefix/tag :foo}
+             {:field/name "cf1", :ns-prefix/tag :bar}}))))


### PR DESCRIPTION
Needed to tag with more information than a simple boolean, specifically to add a prefix for namespaces by tagging instead of in an ad-hoc manner for each plugin.

Won't break anything, but tagging with a keyword precludes using `only` and `except`, which might be confusing.
